### PR TITLE
Add log to aps to show which profile and region selected

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"regexp"
@@ -137,6 +138,7 @@ func selectProfile(profiles []profile) profile {
 		}
 	}
 
+	fmt.Println("Active Profile: " + profiles[selected].Name)
 	return profiles[selected]
 }
 
@@ -194,6 +196,7 @@ func selectRegion() string {
 		os.Exit(0)
 	}
 
+	fmt.Println("Active Region: " + regions[selected])
 	return regions[selected]
 }
 


### PR DESCRIPTION
- I added log to aps to show which profile and region selected eg: 
  
  - If I selected region "ap-southeast-1", it will print "Active Region: ap-southeast-1".
  - If I selected profile "test", it will print "Active Profile: test".