### PR TITLE
Disable auto-assume + add region selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,12 @@ As a service provider we have to switch all the time between our customers' acco
 usage: aps [<flags>]
 
 Flags:
-      --help    Show context-sensitive help (also try --help-long and --help-man).
-  -x, --clear   Clear env vars related to AWS
-  -c, --config=$HOME/.aws/config
-                AWS config file
-  -r, --region  Region selector
+      --help                     Show context-sensitive help (also try --help-long and --help-man).
+  -x, --clear                    Clear env vars related to AWS
+  -c, --config=$HOME/.aws/config AWS config file
+  -p, --profile=PROFILE          Specify directly the AWS Profile to use
+  -r, --region=REGION            Region selector
+  -a, --assume=ASSUME            If false, auto assume role is disabled (default is true)
 ```
 
 You can select your profile/region by &larr;, &uarr;, &rarr; &darr; and filter by **Name**, or **AccountId** (only for profile). **Enter** key to validate. 
@@ -38,4 +39,4 @@ This repository uses `go mod`, so don't `git clone` inside your `$GOPATH`.
 
 ## Author
 
-Thomas Labarussias (thomas.labarussias@fr.clara.net - https://github.com/Issif)
+Thomas Labarussias (thomas.labarussias@qonto.com - https://github.com/Issif)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ You can select your profile/region by &larr;, &uarr;, &rarr; &darr; and filter b
 ![screenshot1](./img/screenshot1.png)
 ![screenshot2](./img/screenshot2.png)
 
-
 ## Build
 
 ```bash

--- a/main.go
+++ b/main.go
@@ -101,9 +101,6 @@ func listProfiles(configFile *string) []profile {
 		if cfg.Section(n).HasKey("region") {
 			p.Region = cfg.Section(n).Key("region").String()
 		}
-		if p.Name != "DEFAULT" {
-			profiles = append(profiles, p)
-		}
 	}
 
 	return profiles


### PR DESCRIPTION
- new `-a | --assume` option for disabling auto-assume of role (default: `true`), only export of env vars is made
- better `-r | --region` option, if empty a selector in displayd, we an still select by `-r eu-west-3`
- better format for messages about which `profile` and `region` are selected
- remove of useless `DEFAULT` profile from list